### PR TITLE
chore: temporary add `neopolars` (WIP next major breaking-changed version of `polars`)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,6 +5,11 @@
         "branch": "*release"
     },
     {
+        "package": "neopolars",
+        "url": "https://github.com/pola-rs/r-polars",
+        "branch": "next"
+    },
+    {
         "package": "polarssql",
         "url": "https://github.com/rpolars/r-polarssql"
     }


### PR DESCRIPTION
At some point in the future, `neopolars` will be renamed to `polars` and will eventually become unavailable.
(At the same time, the current code base `polars` will no longer be available)

If that occurred and the latest release of `polars` is required, installation from R-multiverse is requiered.